### PR TITLE
two-step pass check and outcome reporting

### DIFF
--- a/gobreaker.go
+++ b/gobreaker.go
@@ -167,6 +167,9 @@ func (cb *CircuitBreaker) State() State {
 // Otherwise, Execute returns the result of the request.
 // If a panic occurs in the request, the CircuitBreaker handles it as an error
 // and causes the same panic again.
+//
+// If the request can not be expressed as a single function you can use Allow
+// in combination with Success or Fail.
 func (cb *CircuitBreaker) Execute(req func() (interface{}, error)) (interface{}, error) {
 	generation, err := cb.beforeRequest()
 	if err != nil {
@@ -186,14 +189,25 @@ func (cb *CircuitBreaker) Execute(req func() (interface{}, error)) (interface{},
 	return result, err
 }
 
+// Allow registers a new request with the CircuitBreaker.
+// Allow returns the current generation. If the Circuit Breaker doesn't allow
+// requests it returns an error.
+//
+// Use Success or Fail with the returned generation to register the outcome of the request.
+//
+// If the request can be expressed as a single function it is recommended to use Execute.
 func (cb *CircuitBreaker) Allow() (uint64, error) {
 	return cb.beforeRequest()
 }
 
+// Success registers a successful outcome for the generation returned by the call to Allow,
+// prior to executing the request.
 func (cb *CircuitBreaker) Success(generation uint64) {
 	cb.afterRequest(generation, true)
 }
 
+// Fail registers a failed outcome for the generation returned by the call to Allow,
+// prior to executing the request.
 func (cb *CircuitBreaker) Fail(generation uint64) {
 	cb.afterRequest(generation, false)
 }

--- a/gobreaker_test.go
+++ b/gobreaker_test.go
@@ -76,32 +76,7 @@ func causePanic(cb *CircuitBreaker) error {
 	return err
 }
 
-func init() {
-	defaultCB = NewCircuitBreaker(Settings{})
-}
-
-func TestStateConstants(t *testing.T) {
-	assert.Equal(t, State(0), StateClosed)
-	assert.Equal(t, State(1), StateHalfOpen)
-	assert.Equal(t, State(2), StateOpen)
-
-	assert.Equal(t, StateClosed.String(), "closed")
-	assert.Equal(t, StateHalfOpen.String(), "half-open")
-	assert.Equal(t, StateOpen.String(), "open")
-	assert.Equal(t, State(100).String(), "unknown state: 100")
-}
-
-func TestNewCircuitBreaker(t *testing.T) {
-	assert.Equal(t, "", defaultCB.name)
-	assert.Equal(t, uint32(1), defaultCB.maxRequests)
-	assert.Equal(t, time.Duration(0), defaultCB.interval)
-	assert.Equal(t, time.Duration(60)*time.Second, defaultCB.timeout)
-	assert.NotNil(t, defaultCB.readyToTrip)
-	assert.Nil(t, defaultCB.onStateChange)
-	assert.Equal(t, StateClosed, defaultCB.state)
-	assert.Equal(t, Counts{0, 0, 0, 0, 0}, defaultCB.counts)
-	assert.True(t, defaultCB.expiry.IsZero())
-
+func newCustom() *CircuitBreaker {
 	var customSt Settings
 	customSt.Name = "cb"
 	customSt.MaxRequests = 3
@@ -118,7 +93,39 @@ func TestNewCircuitBreaker(t *testing.T) {
 	customSt.OnStateChange = func(name string, from State, to State) {
 		stateChange = StateChange{name, from, to}
 	}
-	customCB = NewCircuitBreaker(customSt)
+
+	return NewCircuitBreaker(customSt)
+}
+
+func init() {
+	defaultCB = NewCircuitBreaker(Settings{})
+	customCB = newCustom()
+}
+
+func TestStateConstants(t *testing.T) {
+	assert.Equal(t, State(0), StateClosed)
+	assert.Equal(t, State(1), StateHalfOpen)
+	assert.Equal(t, State(2), StateOpen)
+
+	assert.Equal(t, StateClosed.String(), "closed")
+	assert.Equal(t, StateHalfOpen.String(), "half-open")
+	assert.Equal(t, StateOpen.String(), "open")
+	assert.Equal(t, State(100).String(), "unknown state: 100")
+}
+
+func TestNewCircuitBreaker(t *testing.T) {
+	defaultCB := NewCircuitBreaker(Settings{})
+	assert.Equal(t, "", defaultCB.name)
+	assert.Equal(t, uint32(1), defaultCB.maxRequests)
+	assert.Equal(t, time.Duration(0), defaultCB.interval)
+	assert.Equal(t, time.Duration(60)*time.Second, defaultCB.timeout)
+	assert.NotNil(t, defaultCB.readyToTrip)
+	assert.Nil(t, defaultCB.onStateChange)
+	assert.Equal(t, StateClosed, defaultCB.state)
+	assert.Equal(t, Counts{0, 0, 0, 0, 0}, defaultCB.counts)
+	assert.True(t, defaultCB.expiry.IsZero())
+
+	customCB := newCustom()
 	assert.Equal(t, "cb", customCB.name)
 	assert.Equal(t, uint32(3), customCB.maxRequests)
 	assert.Equal(t, time.Duration(30)*time.Second, customCB.interval)


### PR DESCRIPTION
Closes #4 

Implemented two-step breaker calls: Allow() to check if the request can be passed through, Success() and Fail() to report the outcome.