### PR TITLE
Allow accessing to internal counters (eg. for stats)

### DIFF
--- a/gobreaker.go
+++ b/gobreaker.go
@@ -189,6 +189,11 @@ func (cb *CircuitBreaker) State() State {
 	return state
 }
 
+// Returns internal counters
+func (cb *CircuitBreaker) Counts() Counts {
+	return cb.counts
+}
+
 // Execute runs the given request if the CircuitBreaker accepts it.
 // Execute returns an error instantly if the CircuitBreaker rejects the request.
 // Otherwise, Execute returns the result of the request.
@@ -221,6 +226,11 @@ func (tscb *TwoStepCircuitBreaker) Name() string {
 // State returns the current state of the TwoStepCircuitBreaker.
 func (tscb *TwoStepCircuitBreaker) State() State {
 	return tscb.cb.State()
+}
+
+// Returns internal counters
+func (tscb *TwoStepCircuitBreaker) Counts() Counts {
+	return tscb.cb.Counts()
 }
 
 // Allow checks if a new request can proceed. It returns a callback that should be used to

--- a/gobreaker.go
+++ b/gobreaker.go
@@ -189,8 +189,11 @@ func (cb *CircuitBreaker) State() State {
 	return state
 }
 
-// Returns internal counters
+// Counts returns internal counters
 func (cb *CircuitBreaker) Counts() Counts {
+	cb.mutex.Lock()
+	defer cb.mutex.Unlock()
+
 	return cb.counts
 }
 
@@ -228,7 +231,7 @@ func (tscb *TwoStepCircuitBreaker) State() State {
 	return tscb.cb.State()
 }
 
-// Returns internal counters
+// Counts returns internal counters
 func (tscb *TwoStepCircuitBreaker) Counts() Counts {
 	return tscb.cb.Counts()
 }


### PR DESCRIPTION
This patch adds a method to accessing internal counters (which are not exported). This can be useful when debugging or collecting data for metrics.