### PR TITLE
Allow custom inspection of errors

### DIFF
--- a/gobreaker.go
+++ b/gobreaker.go
@@ -232,7 +232,7 @@ func (cb *CircuitBreaker) Execute(req func() (interface{}, error)) (interface{},
 	}()
 
 	result, err := req()
-	cb.afterRequest(generation, cb.shouldTrip(err))
+	cb.afterRequest(generation, !cb.shouldTrip(err))
 	return result, err
 }
 

--- a/gobreaker.go
+++ b/gobreaker.go
@@ -99,10 +99,10 @@ func (c *Counts) clear() {
 //
 // OnStateChange is called whenever the state of the CircuitBreaker changes.
 //
-// ShouldTrip is called with the error returned from the request, if not nil.
-// If ShouldTrip returns true, the error is considered a failure, and is counted towards tripping the circuit breaker.
-// If ShouldTrip returns false, the error will be returned to the caller without tripping the circuit breaker.
-// If ShouldTrip is nil, default ShouldTrip is used, which returns true for all non-nil errors.
+// IsSuccessful is called with the error returned from the request, if not nil.
+// If IsSuccessful returns true, the error is considered a failure, and is counted towards tripping the circuit breaker.
+// If IsSuccessful returns false, the error will be returned to the caller without tripping the circuit breaker.
+// If IsSuccessful is nil, default IsSuccessful is used, which returns true for all non-nil errors.
 type Settings struct {
 	Name          string
 	MaxRequests   uint32
@@ -110,7 +110,7 @@ type Settings struct {
 	Timeout       time.Duration
 	ReadyToTrip   func(counts Counts) bool
 	OnStateChange func(name string, from State, to State)
-	ShouldTrip    func(err error) bool
+	IsSuccessful  func(err error) bool
 }
 
 // CircuitBreaker is a state machine to prevent sending requests that are likely to fail.
@@ -168,10 +168,10 @@ func NewCircuitBreaker(st Settings) *CircuitBreaker {
 		cb.readyToTrip = st.ReadyToTrip
 	}
 
-	if st.ShouldTrip == nil {
+	if st.IsSuccessful == nil {
 		cb.shouldTrip = defaultShouldTrip
 	} else {
-		cb.shouldTrip = st.ShouldTrip
+		cb.shouldTrip = st.IsSuccessful
 	}
 
 	cb.toNewGeneration(time.Now())

--- a/gobreaker.go
+++ b/gobreaker.go
@@ -98,6 +98,11 @@ func (c *Counts) clear() {
 // Default ReadyToTrip returns true when the number of consecutive failures is more than 5.
 //
 // OnStateChange is called whenever the state of the CircuitBreaker changes.
+//
+// ShouldTrip is called with the error returned from the request, if not nil.
+// If ShouldTrip returns true, the error is considered a failure, and is counted towards tripping the circuit breaker.
+// If ShouldTrip returns false, the error will be returned to the caller without tripping the circuit breaker.
+// If ShouldTrip is nil, default ShouldTrip is used, which returns true for all non-nil errors.
 type Settings struct {
 	Name          string
 	MaxRequests   uint32
@@ -105,6 +110,7 @@ type Settings struct {
 	Timeout       time.Duration
 	ReadyToTrip   func(counts Counts) bool
 	OnStateChange func(name string, from State, to State)
+	ShouldTrip    func(err error) bool
 }
 
 // CircuitBreaker is a state machine to prevent sending requests that are likely to fail.
@@ -114,6 +120,7 @@ type CircuitBreaker struct {
 	interval      time.Duration
 	timeout       time.Duration
 	readyToTrip   func(counts Counts) bool
+	shouldTrip    func(err error) bool
 	onStateChange func(name string, from State, to State)
 
 	mutex      sync.Mutex
@@ -161,6 +168,12 @@ func NewCircuitBreaker(st Settings) *CircuitBreaker {
 		cb.readyToTrip = st.ReadyToTrip
 	}
 
+	if st.ShouldTrip == nil {
+		cb.shouldTrip = defaultShouldTrip
+	} else {
+		cb.shouldTrip = st.ShouldTrip
+	}
+
 	cb.toNewGeneration(time.Now())
 
 	return cb
@@ -178,6 +191,10 @@ const defaultTimeout = time.Duration(60) * time.Second
 
 func defaultReadyToTrip(counts Counts) bool {
 	return counts.ConsecutiveFailures > 5
+}
+
+func defaultShouldTrip(err error) bool {
+	return err != nil
 }
 
 // Name returns the name of the CircuitBreaker.
@@ -215,7 +232,7 @@ func (cb *CircuitBreaker) Execute(req func() (interface{}, error)) (interface{},
 	}()
 
 	result, err := req()
-	cb.afterRequest(generation, err == nil)
+	cb.afterRequest(generation, cb.shouldTrip(err))
 	return result, err
 }
 

--- a/gobreaker.go
+++ b/gobreaker.go
@@ -194,7 +194,7 @@ func defaultReadyToTrip(counts Counts) bool {
 }
 
 func defaultIsSuccessful(err error) bool {
-	return err != nil
+	return err == nil
 }
 
 // Name returns the name of the CircuitBreaker.

--- a/gobreaker_test.go
+++ b/gobreaker_test.go
@@ -344,6 +344,30 @@ func TestGeneration(t *testing.T) {
 	assert.Equal(t, Counts{0, 0, 0, 0, 0}, customCB.counts)
 }
 
+func TestCustomIsSuccessful(t *testing.T) {
+	isSuccessful := func(error) bool {
+		return true
+	}
+	cb := NewCircuitBreaker(Settings{IsSuccessful: isSuccessful})
+
+	for i := 0; i < 5; i++ {
+		assert.Nil(t, fail(cb))
+	}
+	assert.Equal(t, StateClosed, cb.State())
+	assert.Equal(t, Counts{5, 5, 0, 5, 0}, cb.counts)
+
+	cb.counts.clear()
+
+	cb.isSuccessful = func(err error) bool {
+		return err == nil
+	}
+	for i := 0; i < 6; i++ {
+		assert.Nil(t, fail(cb))
+	}
+	assert.Equal(t, StateOpen, cb.State())
+
+}
+
 func TestCircuitBreakerInParallel(t *testing.T) {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 


### PR DESCRIPTION
Not all errors should be counted towards tripping the circuit breaker, this PR adds support for a custom inspection strategy to determine if an error should trip the circuit breaker or not.