### PR TITLE
Adjust counters to work with metrics usage

### DIFF
--- a/gobreaker.go
+++ b/gobreaker.go
@@ -70,8 +70,6 @@ func (c *Counts) onFailure() {
 
 func (c *Counts) clear() {
 	c.Requests = 0
-	c.TotalSuccesses = 0
-	c.TotalFailures = 0
 	c.ConsecutiveSuccesses = 0
 	c.ConsecutiveFailures = 0
 }

--- a/gobreaker.go
+++ b/gobreaker.go
@@ -49,7 +49,11 @@ type Counts struct {
 	TotalSuccesses       uint32
 	TotalFailures        uint32
 	ConsecutiveSuccesses uint32
-	ConsecutiveFailures  uint32
+	// internalConsecutiveFailures is for gobreaker to keep track of what is happening.
+	internalConsecutiveFailures uint32
+	// ConsecutiveFailures tracks consecutive failures, including between different circuit breaker states.
+	// This is not reset when state changes i.e., from open to half-open.
+	ConsecutiveFailures uint32
 }
 
 func (c *Counts) onRequest() {
@@ -59,19 +63,21 @@ func (c *Counts) onRequest() {
 func (c *Counts) onSuccess() {
 	c.TotalSuccesses++
 	c.ConsecutiveSuccesses++
+	c.internalConsecutiveFailures = 0
 	c.ConsecutiveFailures = 0
 }
 
 func (c *Counts) onFailure() {
 	c.TotalFailures++
-	c.ConsecutiveFailures++
+	c.internalConsecutiveFailures++
 	c.ConsecutiveSuccesses = 0
+	c.ConsecutiveFailures++
 }
 
 func (c *Counts) clear() {
 	c.Requests = 0
 	c.ConsecutiveSuccesses = 0
-	c.ConsecutiveFailures = 0
+	c.internalConsecutiveFailures = 0
 }
 
 // Settings configures CircuitBreaker:
@@ -188,7 +194,7 @@ const defaultInterval = time.Duration(0) * time.Second
 const defaultTimeout = time.Duration(60) * time.Second
 
 func defaultReadyToTrip(counts Counts) bool {
-	return counts.ConsecutiveFailures > 5
+	return counts.internalConsecutiveFailures > 5
 }
 
 func defaultIsSuccessful(err error) bool {

--- a/gobreaker_test.go
+++ b/gobreaker_test.go
@@ -124,7 +124,7 @@ func TestNewCircuitBreaker(t *testing.T) {
 	assert.NotNil(t, defaultCB.readyToTrip)
 	assert.Nil(t, defaultCB.onStateChange)
 	assert.Equal(t, StateClosed, defaultCB.state)
-	assert.Equal(t, Counts{0, 0, 0, 0, 0}, defaultCB.counts)
+	assert.Equal(t, Counts{0, 0, 0, 0, 0, 0}, defaultCB.counts)
 	assert.True(t, defaultCB.expiry.IsZero())
 
 	customCB := newCustom()
@@ -135,7 +135,7 @@ func TestNewCircuitBreaker(t *testing.T) {
 	assert.NotNil(t, customCB.readyToTrip)
 	assert.NotNil(t, customCB.onStateChange)
 	assert.Equal(t, StateClosed, customCB.state)
-	assert.Equal(t, Counts{0, 0, 0, 0, 0}, customCB.counts)
+	assert.Equal(t, Counts{0, 0, 0, 0, 0, 0}, customCB.counts)
 	assert.False(t, customCB.expiry.IsZero())
 
 	negativeDurationCB := newNegativeDurationCB()
@@ -146,7 +146,7 @@ func TestNewCircuitBreaker(t *testing.T) {
 	assert.NotNil(t, negativeDurationCB.readyToTrip)
 	assert.Nil(t, negativeDurationCB.onStateChange)
 	assert.Equal(t, StateClosed, negativeDurationCB.state)
-	assert.Equal(t, Counts{0, 0, 0, 0, 0}, negativeDurationCB.counts)
+	assert.Equal(t, Counts{0, 0, 0, 0, 0, 0}, negativeDurationCB.counts)
 	assert.True(t, negativeDurationCB.expiry.IsZero())
 }
 
@@ -159,27 +159,27 @@ func TestDefaultCircuitBreaker(t *testing.T) {
 		assert.Nil(t, fail(defaultCB))
 	}
 	assert.Equal(t, StateClosed, defaultCB.State())
-	assert.Equal(t, Counts{5, 0, 5, 0, 5}, defaultCB.counts)
+	assert.Equal(t, Counts{5, 0, 5, 0, 5, 5}, defaultCB.counts)
 
 	assert.Nil(t, succeed(defaultCB))
 	assert.Equal(t, StateClosed, defaultCB.State())
-	assert.Equal(t, Counts{6, 1, 5, 1, 0}, defaultCB.counts)
+	assert.Equal(t, Counts{6, 1, 5, 1, 0, 0}, defaultCB.counts)
 
 	assert.Nil(t, fail(defaultCB))
 	assert.Equal(t, StateClosed, defaultCB.State())
-	assert.Equal(t, Counts{7, 1, 6, 0, 1}, defaultCB.counts)
+	assert.Equal(t, Counts{7, 1, 6, 0, 1, 1}, defaultCB.counts)
 
 	// StateClosed to StateOpen
 	for i := 0; i < 5; i++ {
 		assert.Nil(t, fail(defaultCB)) // 6 consecutive failures
 	}
 	assert.Equal(t, StateOpen, defaultCB.State())
-	assert.Equal(t, Counts{0, 1, 11, 0, 0}, defaultCB.counts)
+	assert.Equal(t, Counts{0, 1, 11, 0, 0, 6}, defaultCB.counts)
 	assert.False(t, defaultCB.expiry.IsZero())
 
 	assert.Error(t, succeed(defaultCB))
 	assert.Error(t, fail(defaultCB))
-	assert.Equal(t, Counts{0, 1, 11, 0, 0}, defaultCB.counts)
+	assert.Equal(t, Counts{0, 1, 11, 0, 0, 6}, defaultCB.counts)
 
 	pseudoSleep(defaultCB, time.Duration(59)*time.Second)
 	assert.Equal(t, StateOpen, defaultCB.State())
@@ -192,7 +192,7 @@ func TestDefaultCircuitBreaker(t *testing.T) {
 	// StateHalfOpen to StateOpen
 	assert.Nil(t, fail(defaultCB))
 	assert.Equal(t, StateOpen, defaultCB.State())
-	assert.Equal(t, Counts{0, 1, 11, 0, 0}, defaultCB.counts)
+	assert.Equal(t, Counts{0, 1, 11, 0, 0, 6}, defaultCB.counts)
 	assert.False(t, defaultCB.expiry.IsZero())
 
 	// StateOpen to StateHalfOpen
@@ -203,7 +203,7 @@ func TestDefaultCircuitBreaker(t *testing.T) {
 	// StateHalfOpen to StateClosed
 	assert.Nil(t, succeed(defaultCB))
 	assert.Equal(t, StateClosed, defaultCB.State())
-	assert.Equal(t, Counts{0, 2, 11, 0, 0}, defaultCB.counts)
+	assert.Equal(t, Counts{0, 2, 11, 0, 0, 0}, defaultCB.counts)
 	assert.True(t, defaultCB.expiry.IsZero())
 }
 
@@ -218,23 +218,23 @@ func TestCustomCircuitBreaker(t *testing.T) {
 		assert.Nil(t, fail(customCB))
 	}
 	assert.Equal(t, StateClosed, customCB.State())
-	assert.Equal(t, Counts{10, 5, 5, 0, 1}, customCB.counts)
+	assert.Equal(t, Counts{10, 5, 5, 0, 1, 1}, customCB.counts)
 
 	pseudoSleep(customCB, time.Duration(29)*time.Second)
 	assert.Nil(t, succeed(customCB))
 	assert.Equal(t, StateClosed, customCB.State())
-	assert.Equal(t, Counts{11, 6, 5, 1, 0}, customCB.counts)
+	assert.Equal(t, Counts{11, 6, 5, 1, 0, 0}, customCB.counts)
 
 	pseudoSleep(customCB, time.Duration(1)*time.Second) // over Interval
 	assert.Nil(t, fail(customCB))
 	assert.Equal(t, StateClosed, customCB.State())
-	assert.Equal(t, Counts{1, 6, 6, 0, 1}, customCB.counts)
+	assert.Equal(t, Counts{1, 6, 6, 0, 1, 1}, customCB.counts)
 
 	// StateClosed to StateOpen
 	assert.Nil(t, succeed(customCB))
 	assert.Nil(t, fail(customCB)) // failure ratio: 2/3 >= 0.6
 	assert.Equal(t, StateOpen, customCB.State())
-	assert.Equal(t, Counts{0, 7, 7, 0, 0}, customCB.counts)
+	assert.Equal(t, Counts{0, 7, 7, 0, 0, 1}, customCB.counts)
 	assert.False(t, customCB.expiry.IsZero())
 	assert.Equal(t, StateChange{"cb", StateClosed, StateOpen}, stateChange)
 
@@ -247,16 +247,16 @@ func TestCustomCircuitBreaker(t *testing.T) {
 	assert.Nil(t, succeed(customCB))
 	assert.Nil(t, succeed(customCB))
 	assert.Equal(t, StateHalfOpen, customCB.State())
-	assert.Equal(t, Counts{2, 9, 7, 2, 0}, customCB.counts)
+	assert.Equal(t, Counts{2, 9, 7, 2, 0, 0}, customCB.counts)
 
 	// StateHalfOpen to StateClosed
 	ch := succeedLater(customCB, time.Duration(100)*time.Millisecond) // 3 consecutive successes
 	time.Sleep(time.Duration(50) * time.Millisecond)
-	assert.Equal(t, Counts{3, 9, 7, 2, 0}, customCB.counts)
+	assert.Equal(t, Counts{3, 9, 7, 2, 0, 0}, customCB.counts)
 	assert.Error(t, succeed(customCB)) // over MaxRequests
 	assert.Nil(t, <-ch)
 	assert.Equal(t, StateClosed, customCB.State())
-	assert.Equal(t, Counts{0, 10, 7, 0, 0}, customCB.counts)
+	assert.Equal(t, Counts{0, 10, 7, 0, 0, 0}, customCB.counts)
 	assert.False(t, customCB.expiry.IsZero())
 	assert.Equal(t, StateChange{"cb", StateHalfOpen, StateClosed}, stateChange)
 }
@@ -270,27 +270,27 @@ func TestTwoStepCircuitBreaker(t *testing.T) {
 	}
 
 	assert.Equal(t, StateClosed, tscb.State())
-	assert.Equal(t, Counts{5, 0, 5, 0, 5}, tscb.cb.counts)
+	assert.Equal(t, Counts{5, 0, 5, 0, 5, 5}, tscb.cb.counts)
 
 	assert.Nil(t, succeed2Step(tscb))
 	assert.Equal(t, StateClosed, tscb.State())
-	assert.Equal(t, Counts{6, 1, 5, 1, 0}, tscb.cb.counts)
+	assert.Equal(t, Counts{6, 1, 5, 1, 0, 0}, tscb.cb.counts)
 
 	assert.Nil(t, fail2Step(tscb))
 	assert.Equal(t, StateClosed, tscb.State())
-	assert.Equal(t, Counts{7, 1, 6, 0, 1}, tscb.cb.counts)
+	assert.Equal(t, Counts{7, 1, 6, 0, 1, 1}, tscb.cb.counts)
 
 	// StateClosed to StateOpen
 	for i := 0; i < 5; i++ {
 		assert.Nil(t, fail2Step(tscb)) // 6 consecutive failures
 	}
 	assert.Equal(t, StateOpen, tscb.State())
-	assert.Equal(t, Counts{0, 1, 11, 0, 0}, tscb.cb.counts)
+	assert.Equal(t, Counts{0, 1, 11, 0, 0, 6}, tscb.cb.counts)
 	assert.False(t, tscb.cb.expiry.IsZero())
 
 	assert.Error(t, succeed2Step(tscb))
 	assert.Error(t, fail2Step(tscb))
-	assert.Equal(t, Counts{0, 1, 11, 0, 0}, tscb.cb.counts)
+	assert.Equal(t, Counts{0, 1, 11, 0, 0, 6}, tscb.cb.counts)
 
 	pseudoSleep(tscb.cb, time.Duration(59)*time.Second)
 	assert.Equal(t, StateOpen, tscb.State())
@@ -303,7 +303,7 @@ func TestTwoStepCircuitBreaker(t *testing.T) {
 	// StateHalfOpen to StateOpen
 	assert.Nil(t, fail2Step(tscb))
 	assert.Equal(t, StateOpen, tscb.State())
-	assert.Equal(t, Counts{0, 1, 11, 0, 0}, tscb.cb.counts)
+	assert.Equal(t, Counts{0, 1, 11, 0, 0, 6}, tscb.cb.counts)
 	assert.False(t, tscb.cb.expiry.IsZero())
 
 	// StateOpen to StateHalfOpen
@@ -314,34 +314,34 @@ func TestTwoStepCircuitBreaker(t *testing.T) {
 	// StateHalfOpen to StateClosed
 	assert.Nil(t, succeed2Step(tscb))
 	assert.Equal(t, StateClosed, tscb.State())
-	assert.Equal(t, Counts{0, 2, 11, 0, 0}, tscb.cb.counts)
+	assert.Equal(t, Counts{0, 2, 11, 0, 0, 0}, tscb.cb.counts)
 	assert.True(t, tscb.cb.expiry.IsZero())
 }
 
 func TestPanicInRequest(t *testing.T) {
 	defaultCB := NewCircuitBreaker(Settings{})
 	assert.Panics(t, func() { causePanic(defaultCB) })
-	assert.Equal(t, Counts{1, 0, 1, 0, 1}, defaultCB.counts)
+	assert.Equal(t, Counts{1, 0, 1, 0, 1, 1}, defaultCB.counts)
 }
 
 func TestGeneration(t *testing.T) {
 	customCB := newCustom()
-	assert.Equal(t, Counts{0, 0, 0, 0, 0}, customCB.counts)
+	assert.Equal(t, Counts{0, 0, 0, 0, 0, 0}, customCB.counts)
 	pseudoSleep(customCB, time.Duration(29)*time.Second)
 	assert.Nil(t, succeed(customCB))
-	assert.Equal(t, Counts{1, 1, 0, 1, 0}, customCB.counts) // A single successful request
+	assert.Equal(t, Counts{1, 1, 0, 1, 0, 0}, customCB.counts) // A single successful request
 	ch := succeedLater(customCB, time.Duration(1500)*time.Millisecond)
-	assert.Equal(t, Counts{1, 1, 0, 1, 0}, customCB.counts) // A single successful request - we didn't execute succeedLater yet
+	assert.Equal(t, Counts{1, 1, 0, 1, 0, 0}, customCB.counts) // A single successful request - we didn't execute succeedLater yet
 	time.Sleep(time.Duration(500) * time.Millisecond)
-	assert.Equal(t, Counts{2, 1, 0, 1, 0}, customCB.counts)
+	assert.Equal(t, Counts{2, 1, 0, 1, 0, 0}, customCB.counts)
 
 	time.Sleep(time.Duration(500) * time.Millisecond) // over Interval
 	assert.Equal(t, StateClosed, customCB.State())
-	assert.Equal(t, Counts{0, 1, 0, 0, 0}, customCB.counts)
+	assert.Equal(t, Counts{0, 1, 0, 0, 0, 0}, customCB.counts)
 
 	// the request from the previous generation has no effect on customCB.counts
 	assert.Nil(t, <-ch)
-	assert.Equal(t, Counts{0, 1, 0, 0, 0}, customCB.counts)
+	assert.Equal(t, Counts{0, 1, 0, 0, 0, 0}, customCB.counts)
 }
 
 func TestCustomIsSuccessful(t *testing.T) {
@@ -354,7 +354,7 @@ func TestCustomIsSuccessful(t *testing.T) {
 		assert.Nil(t, fail(cb))
 	}
 	assert.Equal(t, StateClosed, cb.State())
-	assert.Equal(t, Counts{5, 5, 0, 5, 0}, cb.counts)
+	assert.Equal(t, Counts{5, 5, 0, 5, 0, 0}, cb.counts)
 
 	cb.counts.clear()
 
@@ -391,5 +391,5 @@ func TestCircuitBreakerInParallel(t *testing.T) {
 		err := <-ch
 		assert.Nil(t, err)
 	}
-	assert.Equal(t, Counts{total, total, 0, total, 0}, customCB.counts)
+	assert.Equal(t, Counts{total, total, 0, total, 0, 0}, customCB.counts)
 }


### PR DESCRIPTION
With implementation in master, for a flapping breaker (for example, open - half-open) all counters are reset at the each state change. This means metrics would show 0 requests, 0 failures, which isn't ideal.

This change stops resetting totals and implements `ConsecutiveFailures` which only resets when a request succeeds.

This does not change how the breakers behave, only what is exported for metrics.