### PR TITLE
Remove unused test variable

### DIFF
--- a/gobreaker_test.go
+++ b/gobreaker_test.go
@@ -11,7 +11,6 @@ import (
 
 var defaultCB *CircuitBreaker
 var customCB *CircuitBreaker
-var negativeDurationCB *CircuitBreaker
 
 type StateChange struct {
 	name string
@@ -111,7 +110,6 @@ func newNegativeDurationCB() *CircuitBreaker {
 func init() {
 	defaultCB = NewCircuitBreaker(Settings{})
 	customCB = newCustom()
-	negativeDurationCB = newNegativeDurationCB()
 }
 
 func TestStateConstants(t *testing.T) {


### PR DESCRIPTION
This PR removes the `negativeDurationCB` variable which isn't being accessed at all through out the tests i.e. doesn't affect test results/correctness :) 