### PR TITLE
Add expiry getter

### DIFF
--- a/gobreaker.go
+++ b/gobreaker.go
@@ -220,6 +220,14 @@ func (cb *CircuitBreaker) Counts() Counts {
 	return cb.counts
 }
 
+// Expiry returns the time when the state is changed from open to half-open
+func (cb *CircuitBreaker) Expiry() time.Time {
+	cb.mutex.Lock()
+	defer cb.mutex.Unlock()
+
+	return cb.expiry
+}
+
 // Execute runs the given request if the CircuitBreaker accepts it.
 // Execute returns an error instantly if the CircuitBreaker rejects the request.
 // Otherwise, Execute returns the result of the request.


### PR DESCRIPTION
I added a simple getter for the internal expiry field. This is e.g. useful when the circuit breaker is used in the context of http servers / proxies. You could then set a meaningful value for the `Retry-After` header in the response.

Cheers