### PR TITLE
added predicate fn to switch "Half Open" to "Open"

### DIFF
--- a/v2/gobreaker.go
+++ b/v2/gobreaker.go
@@ -111,6 +111,7 @@ type Settings struct {
 	ReadyToTrip   func(counts Counts) bool
 	OnStateChange func(name string, from State, to State)
 	IsSuccessful  func(err error) bool
+	ReadyToOpen   func(counts Counts) bool
 }
 
 // CircuitBreaker is a state machine to prevent sending requests that are likely to fail.
@@ -122,6 +123,7 @@ type CircuitBreaker[T any] struct {
 	readyToTrip   func(counts Counts) bool
 	isSuccessful  func(err error) bool
 	onStateChange func(name string, from State, to State)
+	readyToOpen   func(counts Counts) bool
 
 	mutex      sync.Mutex
 	state      State
@@ -174,6 +176,12 @@ func NewCircuitBreaker[T any](st Settings) *CircuitBreaker[T] {
 		cb.isSuccessful = st.IsSuccessful
 	}
 
+	if st.ReadyToOpen == nil {
+		cb.readyToOpen = defaultReadyToOpen
+	} else {
+		cb.readyToOpen = st.ReadyToOpen
+	}
+
 	cb.toNewGeneration(time.Now())
 
 	return cb
@@ -195,6 +203,10 @@ func defaultReadyToTrip(counts Counts) bool {
 
 func defaultIsSuccessful(err error) bool {
 	return err == nil
+}
+
+func defaultReadyToOpen(counts Counts) bool {
+	return counts.Requests > 0
 }
 
 // Name returns the name of the CircuitBreaker.
@@ -328,7 +340,9 @@ func (cb *CircuitBreaker[T]) onFailure(state State, now time.Time) {
 			cb.setState(StateOpen, now)
 		}
 	case StateHalfOpen:
-		cb.setState(StateOpen, now)
+		if cb.readyToOpen(cb.counts) {
+			cb.setState(StateOpen, now)
+		}
 	}
 }
 


### PR DESCRIPTION
## Description
- Added predicate Fn "ReadyToOpen" for `Settings` and consumed it in `CircuitBreaker` initalization. 
- Added `defaultReadyToOpen` fn implemetation, when parent won't provide one, this will be used as default behaviout. 


## usage
```
cfg := gobreaker.Settings{
		// When to flush counters int the Closed state
		Interval: 5 * time.Second,
		// Time to switch from Open to Half-open
		Timeout: 7 * time.Second,
		// Function with check when to switch from Closed to Open
		ReadyToTrip: shouldBeSwitchedToOpen,
		// set Max Request in Half Open state to 5
		MaxRequests: 5,
		// On State change Handler Fn
		OnStateChange: func(_ string, from gobreaker.State, to gobreaker.State) {
			// Handler for every state change. We'll use for debugging purpose
			logger.Println("state changed from", from.String(), "to", to.String())
		},
		ReadyToOpen: func(counts gobreaker.Counts) bool {
			fmt.Printf("Ready to open called\n")
			return true
		},
	}

```

