### PR TITLE
Manual tripping

### DIFF
--- a/gobreaker.go
+++ b/gobreaker.go
@@ -244,6 +244,14 @@ func (cb *CircuitBreaker) Execute(req func() (interface{}, error)) (interface{},
 	return result, err
 }
 
+// ManuallyTrip sets the CircuitBreaker into the open state.
+// This is useful when wrapping an external dependency that returns rate limiting information.
+// If the dependency is overwhelmed the breaker can be manually tripped straight away to prevent
+// further requests.
+func (cb *CircuitBreaker) ManuallyTrip() {
+	cb.setState(StateOpen, time.Now())
+}
+
 // Name returns the name of the TwoStepCircuitBreaker.
 func (tscb *TwoStepCircuitBreaker) Name() string {
 	return tscb.cb.Name()

--- a/gobreaker_test.go
+++ b/gobreaker_test.go
@@ -211,6 +211,11 @@ func TestDefaultCircuitBreaker(t *testing.T) {
 	assert.Equal(t, StateClosed, defaultCB.State())
 	assert.Equal(t, Counts{0, 0, 0, 0, 0}, defaultCB.counts)
 	assert.True(t, defaultCB.expiry.IsZero())
+
+	// Manually opened
+	assert.Equal(t, StateClosed, defaultCB.State())
+	defaultCB.ManuallyTrip()
+	assert.Equal(t, StateOpen, defaultCB.State())
 }
 
 func TestCustomCircuitBreaker(t *testing.T) {

--- a/v2/gobreaker.go
+++ b/v2/gobreaker.go
@@ -245,6 +245,14 @@ func (cb *CircuitBreaker[T]) Execute(req func() (T, error)) (T, error) {
 	return result, err
 }
 
+// ManuallyTrip sets the CircuitBreaker into the open state.
+// This is useful when wrapping an external dependency that returns rate limiting information.
+// If the dependency is overwhelmed the breaker can be manually tripped straight away to prevent
+// further requests.
+func (cb *CircuitBreaker[T]) ManuallyTrip() {
+	cb.setState(StateOpen, time.Now())
+}
+
 // Name returns the name of the TwoStepCircuitBreaker.
 func (tscb *TwoStepCircuitBreaker[T]) Name() string {
 	return tscb.cb.Name()

--- a/v2/gobreaker_test.go
+++ b/v2/gobreaker_test.go
@@ -211,6 +211,11 @@ func TestDefaultCircuitBreaker(t *testing.T) {
 	assert.Equal(t, StateClosed, defaultCB.State())
 	assert.Equal(t, Counts{0, 0, 0, 0, 0}, defaultCB.counts)
 	assert.True(t, defaultCB.expiry.IsZero())
+
+	// Manually opened
+	assert.Equal(t, StateClosed, defaultCB.State())
+	defaultCB.ManuallyTrip()
+	assert.Equal(t, StateOpen, defaultCB.State())
 }
 
 func TestCustomCircuitBreaker(t *testing.T) {


### PR DESCRIPTION
I'm working on some software where the dependency that we have wrapped in a circuit breaker sometimes returns an http 429 to indicate it is overwhelmed. In these cases it would be nice to manually trip the breaker as we know any requests in the next X seconds will fail anyway.