### PR TITLE
Time-based Rolling window

### DIFF
--- a/v2/distributed_gobreaker_test.go
+++ b/v2/distributed_gobreaker_test.go
@@ -58,6 +58,7 @@ func dcbPseudoSleep(dcb *DistributedCircuitBreaker[any], period time.Duration) {
 	// Reset counts if the interval has passed
 	if time.Now().After(state.Expiry) {
 		state.Counts = Counts{}
+		state.BucketCounts = []Counts{}
 	}
 
 	err = dcb.setSharedState(state)

--- a/v2/gobreaker.go
+++ b/v2/gobreaker.go
@@ -458,7 +458,7 @@ func (cb *CircuitBreaker[T]) currentState(now time.Time) (State, uint64) {
 	switch cb.state {
 	case StateClosed:
 		if !cb.expiry.IsZero() && cb.expiry.Before(now) {
-			cb.toNewBucket(now)
+			cb.toNewBucket(cb.expiry)
 		}
 	case StateOpen:
 		if cb.expiry.Before(now) {
@@ -506,11 +506,11 @@ func (cb *CircuitBreaker[T]) toNewGeneration(now time.Time) {
 	cb.updateExpiry(now)
 }
 
-func (cb *CircuitBreaker[T]) toNewBucket(now time.Time) {
+func (cb *CircuitBreaker[T]) toNewBucket(lastExpiry time.Time) {
 	cb.windowCounts.bucketGeneration++
 	if cb.windowCounts.bucketGeneration == int(cb.windowCounts.numBuckets) {
 		cb.generation++
 	}
 	cb.windowCounts.rotate()
-	cb.updateExpiry(now)
+	cb.updateExpiry(lastExpiry)
 }

--- a/v2/gobreaker.go
+++ b/v2/gobreaker.go
@@ -221,20 +221,17 @@ type Settings struct {
 
 // CircuitBreaker is a state machine to prevent sending requests that are likely to fail.
 type CircuitBreaker[T any] struct {
-	name        string
-	maxRequests uint32
-	interval    time.Duration
-	// numBuckets    int64
+	name          string
+	maxRequests   uint32
+	interval      time.Duration
 	timeout       time.Duration
 	readyToTrip   func(counts Counts) bool
 	isSuccessful  func(err error) bool
 	onStateChange func(name string, from State, to State)
 
-	mutex      sync.Mutex
-	state      State
-	generation uint64
-	// counts       Counts
-	// bucketCounts *list.List
+	mutex        sync.Mutex
+	state        State
+	generation   uint64
 	windowCounts *WindowCounts
 	expiry       time.Time
 }


### PR DESCRIPTION
Add support for time-based rolling window.
Add BucketPeriod to the struct Settings, as specified in https://github.com/sony/gobreaker/wiki/Draft-Specification-for-Time%E2%80%90Based-Rolling-Window

It uses a double linked list, from the standard package `container/list`, to store the `BucketCounts`.

The `counts` is encapsulated in
```
type WindowCounts struct {
	Counts
	mutex            sync.Mutex
	numBuckets       int64
	bucketCounts     *list.List
	bucketGeneration int
}
```

https://github.com/sony/gobreaker/issues/64