### PR TITLE
feat(circuitbreaker): add tri-state outcome evaluation with Excluded support

### DIFF
--- a/v2/distributed_gobreaker_test.go
+++ b/v2/distributed_gobreaker_test.go
@@ -182,12 +182,12 @@ func TestDistributedCircuitBreakerCounts(t *testing.T) {
 	}
 
 	state, err := dcb.getSharedState()
-	assert.Equal(t, Counts{5, 5, 0, 5, 0}, state.Counts)
+	assert.Equal(t, Counts{Requests: 5, TotalSuccesses: 5, ConsecutiveSuccesses: 5}, state.Counts)
 	assert.NoError(t, err)
 
 	assert.Nil(t, failRequest(dcb))
 	state, err = dcb.getSharedState()
-	assert.Equal(t, Counts{6, 5, 1, 0, 1}, state.Counts)
+	assert.Equal(t, Counts{Requests: 6, TotalSuccesses: 5, TotalFailures: 1, ConsecutiveFailures: 1}, state.Counts)
 	assert.NoError(t, err)
 }
 
@@ -221,13 +221,13 @@ func TestCustomDistributedCircuitBreaker(t *testing.T) {
 		state, err := customDCB.getSharedState()
 		assert.NoError(t, err)
 		assert.Equal(t, StateClosed, state.State)
-		assert.Equal(t, Counts{10, 5, 5, 0, 1}, state.Counts)
+		assert.Equal(t, Counts{Requests: 10, TotalSuccesses: 5, TotalFailures: 5, ConsecutiveFailures: 1}, state.Counts)
 
 		// Perform one more successful request
 		assert.NoError(t, successRequest(customDCB))
 		state, err = customDCB.getSharedState()
 		assert.NoError(t, err)
-		assert.Equal(t, Counts{11, 6, 5, 1, 0}, state.Counts)
+		assert.Equal(t, Counts{Requests: 11, TotalSuccesses: 6, TotalFailures: 5, ConsecutiveSuccesses: 1}, state.Counts)
 
 		// Simulate time passing to reset counts
 		dcbPseudoSleep(customDCB, time.Second*30)
@@ -242,7 +242,7 @@ func TestCustomDistributedCircuitBreaker(t *testing.T) {
 
 		state, err = customDCB.getSharedState()
 		assert.NoError(t, err)
-		assert.Equal(t, Counts{0, 0, 0, 0, 0}, state.Counts)
+		assert.Equal(t, Counts{}, state.Counts)
 	})
 
 	t.Run("Timeout and Half-Open State", func(t *testing.T) {

--- a/v2/gobreaker_test.go
+++ b/v2/gobreaker_test.go
@@ -4,10 +4,16 @@ import (
 	"errors"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+)
+
+var (
+	errFailure  = errors.New("fail")
+	errExcluded = errors.New("excluded")
 )
 
 type StateChange struct {
@@ -41,9 +47,16 @@ func succeedLater(cb *CircuitBreaker[bool], delay time.Duration) <-chan error {
 }
 
 func fail(cb *CircuitBreaker[bool]) error {
-	msg := "fail"
-	_, err := cb.Execute(func() (bool, error) { return false, errors.New(msg) })
-	if err.Error() == msg {
+	_, err := cb.Execute(func() (bool, error) { return false, errFailure })
+	if errors.Is(err, errFailure) {
+		return nil
+	}
+	return err
+}
+
+func exclude(cb *CircuitBreaker[bool]) error {
+	_, err := cb.Execute(func() (bool, error) { return false, errExcluded })
+	if errors.Is(err, errExcluded) {
 		return nil
 	}
 	return err
@@ -61,7 +74,7 @@ func newCustom(stateChange *StateChange) *CircuitBreaker[bool] {
 	customSt.Interval = time.Duration(30) * time.Second
 	customSt.Timeout = time.Duration(90) * time.Second
 	customSt.ReadyToTrip = func(counts Counts) bool {
-		numReqs := counts.Requests
+		numReqs := counts.Requests - counts.TotalExcludes
 		failureRatio := float64(counts.TotalFailures) / float64(numReqs)
 
 		return numReqs >= 3 && failureRatio >= 0.6
@@ -70,6 +83,9 @@ func newCustom(stateChange *StateChange) *CircuitBreaker[bool] {
 		customSt.OnStateChange = func(name string, from State, to State) {
 			*stateChange = StateChange{name, from, to}
 		}
+	}
+	customSt.Exclude = func(err error) bool {
+		return errors.Is(err, errExcluded)
 	}
 
 	return NewCircuitBreaker[bool](customSt)
@@ -83,7 +99,7 @@ func newRollingWindow(stateChange *StateChange) *CircuitBreaker[bool] {
 	rollingWindowSt.BucketPeriod = time.Duration(3) * time.Second
 	rollingWindowSt.Timeout = time.Duration(90) * time.Second
 	rollingWindowSt.ReadyToTrip = func(counts Counts) bool {
-		numReqs := counts.Requests
+		numReqs := counts.Requests - counts.TotalExcludes
 		failureRatio := float64(counts.TotalFailures) / float64(numReqs)
 
 		return numReqs >= 3 && failureRatio >= 0.6
@@ -92,6 +108,9 @@ func newRollingWindow(stateChange *StateChange) *CircuitBreaker[bool] {
 		rollingWindowSt.OnStateChange = func(name string, from State, to State) {
 			*stateChange = StateChange{name, from, to}
 		}
+	}
+	rollingWindowSt.Exclude = func(err error) bool {
+		return errors.Is(err, errExcluded)
 	}
 
 	return NewCircuitBreaker[bool](rollingWindowSt)
@@ -126,7 +145,7 @@ func TestNewCircuitBreaker(t *testing.T) {
 	assert.NotNil(t, defaultCB.readyToTrip)
 	assert.Nil(t, defaultCB.onStateChange)
 	assert.Equal(t, StateClosed, defaultCB.state)
-	assert.Equal(t, Counts{0, 0, 0, 0, 0}, defaultCB.Counts())
+	assert.Equal(t, Counts{}, defaultCB.Counts())
 	assert.True(t, defaultCB.expiry.IsZero())
 
 	var stateChange StateChange
@@ -138,7 +157,7 @@ func TestNewCircuitBreaker(t *testing.T) {
 	assert.NotNil(t, customCB.readyToTrip)
 	assert.NotNil(t, customCB.onStateChange)
 	assert.Equal(t, StateClosed, customCB.state)
-	assert.Equal(t, Counts{0, 0, 0, 0, 0}, customCB.Counts())
+	assert.Equal(t, Counts{}, customCB.Counts())
 	assert.False(t, customCB.expiry.IsZero())
 
 	rollingWindowCB := newRollingWindow(nil)
@@ -150,7 +169,7 @@ func TestNewCircuitBreaker(t *testing.T) {
 	assert.NotNil(t, rollingWindowCB.readyToTrip)
 	assert.Nil(t, rollingWindowCB.onStateChange)
 	assert.Equal(t, StateClosed, rollingWindowCB.state)
-	assert.Equal(t, Counts{0, 0, 0, 0, 0}, rollingWindowCB.Counts())
+	assert.Equal(t, Counts{}, rollingWindowCB.Counts())
 	assert.True(t, rollingWindowCB.expiry.IsZero())
 
 	negativeDurationCB := newNegativeDurationCB()
@@ -161,7 +180,7 @@ func TestNewCircuitBreaker(t *testing.T) {
 	assert.NotNil(t, negativeDurationCB.readyToTrip)
 	assert.Nil(t, negativeDurationCB.onStateChange)
 	assert.Equal(t, StateClosed, negativeDurationCB.state)
-	assert.Equal(t, Counts{0, 0, 0, 0, 0}, negativeDurationCB.Counts())
+	assert.Equal(t, Counts{}, negativeDurationCB.Counts())
 	assert.True(t, negativeDurationCB.expiry.IsZero())
 }
 
@@ -173,27 +192,27 @@ func TestDefaultCircuitBreaker(t *testing.T) {
 		assert.Nil(t, fail(defaultCB))
 	}
 	assert.Equal(t, StateClosed, defaultCB.State())
-	assert.Equal(t, Counts{5, 0, 5, 0, 5}, defaultCB.Counts())
+	assert.Equal(t, Counts{Requests: 5, TotalFailures: 5, ConsecutiveFailures: 5}, defaultCB.Counts())
 
 	assert.Nil(t, succeed(defaultCB))
 	assert.Equal(t, StateClosed, defaultCB.State())
-	assert.Equal(t, Counts{6, 1, 5, 1, 0}, defaultCB.Counts())
+	assert.Equal(t, Counts{Requests: 6, TotalSuccesses: 1, TotalFailures: 5, ConsecutiveSuccesses: 1}, defaultCB.Counts())
 
 	assert.Nil(t, fail(defaultCB))
 	assert.Equal(t, StateClosed, defaultCB.State())
-	assert.Equal(t, Counts{7, 1, 6, 0, 1}, defaultCB.Counts())
+	assert.Equal(t, Counts{Requests: 7, TotalSuccesses: 1, TotalFailures: 6, ConsecutiveFailures: 1}, defaultCB.Counts())
 
 	// StateClosed to StateOpen
 	for i := 0; i < 5; i++ {
 		assert.Nil(t, fail(defaultCB)) // 6 consecutive failures
 	}
 	assert.Equal(t, StateOpen, defaultCB.State())
-	assert.Equal(t, Counts{0, 0, 0, 0, 0}, defaultCB.Counts())
+	assert.Equal(t, Counts{}, defaultCB.Counts())
 	assert.False(t, defaultCB.expiry.IsZero())
 
 	assert.Error(t, succeed(defaultCB))
 	assert.Error(t, fail(defaultCB))
-	assert.Equal(t, Counts{0, 0, 0, 0, 0}, defaultCB.Counts())
+	assert.Equal(t, Counts{}, defaultCB.Counts())
 
 	pseudoSleep(defaultCB, time.Duration(59)*time.Second)
 	assert.Equal(t, StateOpen, defaultCB.State())
@@ -206,7 +225,7 @@ func TestDefaultCircuitBreaker(t *testing.T) {
 	// StateHalfOpen to StateOpen
 	assert.Nil(t, fail(defaultCB))
 	assert.Equal(t, StateOpen, defaultCB.State())
-	assert.Equal(t, Counts{0, 0, 0, 0, 0}, defaultCB.Counts())
+	assert.Equal(t, Counts{}, defaultCB.Counts())
 	assert.False(t, defaultCB.expiry.IsZero())
 
 	// StateOpen to StateHalfOpen
@@ -217,7 +236,7 @@ func TestDefaultCircuitBreaker(t *testing.T) {
 	// StateHalfOpen to StateClosed
 	assert.Nil(t, succeed(defaultCB))
 	assert.Equal(t, StateClosed, defaultCB.State())
-	assert.Equal(t, Counts{0, 0, 0, 0, 0}, defaultCB.Counts())
+	assert.Equal(t, Counts{}, defaultCB.Counts())
 	assert.True(t, defaultCB.expiry.IsZero())
 }
 
@@ -229,25 +248,26 @@ func TestCustomCircuitBreaker(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		assert.Nil(t, succeed(customCB))
 		assert.Nil(t, fail(customCB))
+		assert.Nil(t, exclude(customCB))
 	}
 	assert.Equal(t, StateClosed, customCB.State())
-	assert.Equal(t, Counts{10, 5, 5, 0, 1}, customCB.Counts())
+	assert.Equal(t, Counts{Requests: 15, TotalSuccesses: 5, TotalFailures: 5, ConsecutiveFailures: 1, TotalExcludes: 5}, customCB.Counts())
 
 	pseudoSleep(customCB, time.Duration(29)*time.Second)
 	assert.Nil(t, succeed(customCB))
 	assert.Equal(t, StateClosed, customCB.State())
-	assert.Equal(t, Counts{11, 6, 5, 1, 0}, customCB.Counts())
+	assert.Equal(t, Counts{Requests: 16, TotalSuccesses: 6, TotalFailures: 5, ConsecutiveSuccesses: 1, TotalExcludes: 5}, customCB.Counts())
 
 	pseudoSleep(customCB, time.Duration(1)*time.Second) // over Interval
 	assert.Nil(t, fail(customCB))
 	assert.Equal(t, StateClosed, customCB.State())
-	assert.Equal(t, Counts{1, 0, 1, 0, 1}, customCB.Counts())
+	assert.Equal(t, Counts{Requests: 1, TotalFailures: 1, ConsecutiveFailures: 1}, customCB.Counts())
 
 	// StateClosed to StateOpen
 	assert.Nil(t, succeed(customCB))
 	assert.Nil(t, fail(customCB)) // failure ratio: 2/3 >= 0.6
 	assert.Equal(t, StateOpen, customCB.State())
-	assert.Equal(t, Counts{0, 0, 0, 0, 0}, customCB.Counts())
+	assert.Equal(t, Counts{}, customCB.Counts())
 	assert.False(t, customCB.expiry.IsZero())
 	assert.Equal(t, StateChange{"cb", StateClosed, StateOpen}, stateChange)
 
@@ -257,19 +277,44 @@ func TestCustomCircuitBreaker(t *testing.T) {
 	assert.True(t, customCB.expiry.IsZero())
 	assert.Equal(t, StateChange{"cb", StateOpen, StateHalfOpen}, stateChange)
 
+	// Excluded requests are neutral in Half-Open state.
+	// They do not affect breaker counts or state transitions.
+	// The condition to stay within MaxRequests should be evaluated as:
+	//   (cb.counts.Requests - cb.counts.TotalExcludes) < cb.maxRequests
+	// This ensures excluded requests don’t cause premature errors.
+	assert.Nil(t, exclude(customCB))
+	assert.Nil(t, exclude(customCB))
+	assert.Nil(t, exclude(customCB))
+	assert.Nil(t, exclude(customCB))
+	assert.Equal(t, StateHalfOpen, customCB.State())
+
+	// Transition: Half-Open → Open
+	// In Half-Open, the first real failure immediately re-opens the breaker.
+	assert.Nil(t, fail(customCB))
+	assert.Equal(t, StateOpen, customCB.State())
+	assert.Equal(t, Counts{}, customCB.Counts())
+	assert.False(t, customCB.expiry.IsZero())
+	assert.Equal(t, StateChange{"cb", StateHalfOpen, StateOpen}, stateChange)
+
+	// Transition: Open → Half-Open (after timeout expires).
+	pseudoSleep(customCB, time.Duration(90)*time.Second)
+	assert.Equal(t, StateHalfOpen, customCB.State())
+
+	// Successes increment counters but do not
+	// close the breaker until the MaxRequests threshold is satisfied.
 	assert.Nil(t, succeed(customCB))
 	assert.Nil(t, succeed(customCB))
 	assert.Equal(t, StateHalfOpen, customCB.State())
-	assert.Equal(t, Counts{2, 2, 0, 2, 0}, customCB.Counts())
+	assert.Equal(t, Counts{Requests: 2, TotalSuccesses: 2, ConsecutiveSuccesses: 2}, customCB.Counts())
 
 	// StateHalfOpen to StateClosed
 	ch := succeedLater(customCB, time.Duration(100)*time.Millisecond) // 3 consecutive successes
 	time.Sleep(time.Duration(50) * time.Millisecond)
-	assert.Equal(t, Counts{3, 2, 0, 2, 0}, customCB.Counts())
+	assert.Equal(t, Counts{Requests: 3, TotalSuccesses: 2, ConsecutiveSuccesses: 2}, customCB.Counts())
 	assert.Error(t, succeed(customCB)) // over MaxRequests
 	assert.Nil(t, <-ch)
 	assert.Equal(t, StateClosed, customCB.State())
-	assert.Equal(t, Counts{0, 0, 0, 0, 0}, customCB.Counts())
+	assert.Equal(t, Counts{}, customCB.Counts())
 	assert.False(t, customCB.expiry.IsZero())
 	assert.Equal(t, StateChange{"cb", StateHalfOpen, StateClosed}, stateChange)
 }
@@ -282,57 +327,66 @@ func TestRollingWindowCircuitBreaker(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		assert.Nil(t, succeed(rollingCB))
 		assert.Nil(t, fail(rollingCB))
+		assert.Nil(t, exclude(rollingCB))
 	}
 	assert.Equal(t, StateClosed, rollingCB.State())
-	assert.Equal(t, Counts{10, 5, 5, 0, 1}, rollingCB.Counts())
+	assert.Equal(t, Counts{Requests: 15, TotalSuccesses: 5, TotalFailures: 5, ConsecutiveFailures: 1, TotalExcludes: 5}, rollingCB.Counts())
 	assert.Equal(t, 10, len(rollingCB.counts.buckets))
-	assert.Equal(t, Counts{10, 5, 5, 0, 1}, rollingCB.counts.bucketAt(0))
+	assert.Equal(t, Counts{Requests: 15, TotalSuccesses: 5, TotalFailures: 5, ConsecutiveFailures: 1, TotalExcludes: 5}, rollingCB.counts.bucketAt(0))
 
 	pseudoSleep(rollingCB, time.Duration(3)*time.Second)
 	assert.Nil(t, succeed(rollingCB))
 	assert.Equal(t, StateClosed, rollingCB.State())
-	assert.Equal(t, Counts{11, 6, 5, 1, 0}, rollingCB.Counts())
+	assert.Equal(t, Counts{Requests: 16, TotalSuccesses: 6, TotalFailures: 5, ConsecutiveSuccesses: 1, TotalExcludes: 5}, rollingCB.Counts())
 	assert.Equal(t, 10, len(rollingCB.counts.buckets))
 	// With circular buffer, previous bucket is at (current-1+len) % len
-	assert.Equal(t, Counts{10, 5, 5, 0, 1}, rollingCB.counts.bucketAt(-1))
-	assert.Equal(t, Counts{1, 1, 0, 1, 0}, rollingCB.counts.bucketAt(0))
+	assert.Equal(t, Counts{Requests: 15, TotalSuccesses: 5, TotalFailures: 5, ConsecutiveFailures: 1, TotalExcludes: 5}, rollingCB.counts.bucketAt(-1))
+	assert.Equal(t, Counts{Requests: 1, TotalSuccesses: 1, ConsecutiveSuccesses: 1}, rollingCB.counts.bucketAt(0))
 
 	pseudoSleep(rollingCB, time.Duration(2)*time.Second)
 	assert.Nil(t, succeed(rollingCB))
+	assert.Nil(t, exclude(rollingCB))
 	assert.Equal(t, StateClosed, rollingCB.State())
 	assert.Equal(t, 10, len(rollingCB.counts.buckets))
-	assert.Equal(t, Counts{12, 7, 5, 2, 0}, rollingCB.Counts())
+	assert.Equal(t, Counts{Requests: 18, TotalSuccesses: 7, TotalFailures: 5, ConsecutiveSuccesses: 2, TotalExcludes: 6}, rollingCB.Counts())
 	// Previous bucket index
-	assert.Equal(t, Counts{10, 5, 5, 0, 1}, rollingCB.counts.bucketAt(-1))
-	assert.Equal(t, Counts{2, 2, 0, 2, 0}, rollingCB.counts.bucketAt(0))
+	assert.Equal(t, Counts{Requests: 15, TotalSuccesses: 5, TotalFailures: 5, ConsecutiveFailures: 1, TotalExcludes: 5}, rollingCB.counts.bucketAt(-1))
+	assert.Equal(t, Counts{Requests: 3, TotalSuccesses: 2, ConsecutiveSuccesses: 2, TotalExcludes: 1}, rollingCB.counts.bucketAt(0))
 
 	pseudoSleep(rollingCB, time.Duration(2)*time.Second)
+	// Capture age before undetermined request
+	beforeAge := rollingCB.counts.age
+	// Run an undetermined request
+	assert.Nil(t, exclude(rollingCB))
+	// Age should increase
+	assert.Greater(t, rollingCB.counts.age, beforeAge)
+	// Next success should increment counts normally
 	assert.Nil(t, succeed(rollingCB))
 	assert.Equal(t, StateClosed, rollingCB.State())
-	assert.Equal(t, Counts{13, 8, 5, 3, 0}, rollingCB.Counts())
+	assert.Equal(t, Counts{Requests: 20, TotalSuccesses: 8, TotalFailures: 5, ConsecutiveSuccesses: 3, TotalExcludes: 7}, rollingCB.Counts())
 	assert.Equal(t, 10, len(rollingCB.counts.buckets))
 	// Calculate indices for buckets relative to current
-	assert.Equal(t, Counts{10, 5, 5, 0, 1}, rollingCB.counts.bucketAt(-2))
-	assert.Equal(t, Counts{2, 2, 0, 2, 0}, rollingCB.counts.bucketAt(-1))
-	assert.Equal(t, Counts{1, 1, 0, 1, 0}, rollingCB.counts.bucketAt(0))
+	assert.Equal(t, Counts{Requests: 15, TotalSuccesses: 5, TotalFailures: 5, ConsecutiveFailures: 1, TotalExcludes: 5}, rollingCB.counts.bucketAt(-2))
+	assert.Equal(t, Counts{Requests: 3, TotalSuccesses: 2, ConsecutiveSuccesses: 2, TotalExcludes: 1}, rollingCB.counts.bucketAt(-1))
+	assert.Equal(t, Counts{Requests: 2, TotalSuccesses: 1, ConsecutiveSuccesses: 1, TotalExcludes: 1}, rollingCB.counts.bucketAt(0))
 
 	pseudoSleep(rollingCB, time.Duration(2)*time.Second)
 	assert.Nil(t, fail(rollingCB))
 	assert.Equal(t, StateClosed, rollingCB.State())
-	assert.Equal(t, Counts{14, 8, 6, 0, 1}, rollingCB.Counts())
+	assert.Equal(t, Counts{Requests: 21, TotalSuccesses: 8, TotalFailures: 6, ConsecutiveFailures: 1, TotalExcludes: 7}, rollingCB.Counts())
 	assert.Equal(t, 10, len(rollingCB.counts.buckets))
 	// Calculate indices for buckets relative to current
-	assert.Equal(t, Counts{10, 5, 5, 0, 1}, rollingCB.counts.bucketAt(-3))
-	assert.Equal(t, Counts{2, 2, 0, 2, 0}, rollingCB.counts.bucketAt(-2))
-	assert.Equal(t, Counts{1, 1, 0, 1, 0}, rollingCB.counts.bucketAt(-1))
-	assert.Equal(t, Counts{1, 0, 1, 0, 1}, rollingCB.counts.bucketAt(0))
+	assert.Equal(t, Counts{Requests: 15, TotalSuccesses: 5, TotalFailures: 5, ConsecutiveFailures: 1, TotalExcludes: 5}, rollingCB.counts.bucketAt(-3))
+	assert.Equal(t, Counts{Requests: 3, TotalSuccesses: 2, ConsecutiveSuccesses: 2, TotalExcludes: 1}, rollingCB.counts.bucketAt(-2))
+	assert.Equal(t, Counts{Requests: 2, TotalSuccesses: 1, ConsecutiveSuccesses: 1, TotalExcludes: 1}, rollingCB.counts.bucketAt(-1))
+	assert.Equal(t, Counts{Requests: 1, TotalFailures: 1, ConsecutiveFailures: 1}, rollingCB.counts.bucketAt(0))
 
 	// fill all the buckets
 	for i := 0; i < 6; i++ {
 		pseudoSleep(rollingCB, time.Duration(3)*time.Second)
 		assert.Nil(t, succeed(rollingCB))
 		assert.Nil(t, fail(rollingCB))
-		assert.Equal(t, Counts{uint32(16 + 2*i), uint32(9 + i), uint32(7 + i), 0, 1}, rollingCB.Counts())
+		assert.Equal(t, Counts{Requests: uint32(23 + 2*i), TotalSuccesses: uint32(9 + i), TotalFailures: uint32(7 + i), ConsecutiveFailures: 1, TotalExcludes: 7}, rollingCB.Counts())
 	}
 
 	assert.Equal(t, 10, len(rollingCB.counts.buckets))
@@ -341,11 +395,11 @@ func TestRollingWindowCircuitBreaker(t *testing.T) {
 	pseudoSleep(rollingCB, time.Duration(3)*time.Second)
 	assert.Nil(t, fail(rollingCB))
 	assert.Equal(t, 10, len(rollingCB.counts.buckets))
-	assert.Equal(t, Counts{17, 9, 8, 0, 2}, rollingCB.Counts())
+	assert.Equal(t, Counts{Requests: 19, TotalSuccesses: 9, TotalFailures: 8, ConsecutiveFailures: 2, TotalExcludes: 2}, rollingCB.Counts())
 
 	for i := 0; i < 5; i++ {
 		assert.Nil(t, fail(rollingCB))
-		assert.Equal(t, Counts{uint32(18 + i), 9, uint32(9 + i), 0, uint32(3 + i)}, rollingCB.Counts())
+		assert.Equal(t, Counts{Requests: uint32(20 + i), TotalSuccesses: 9, TotalFailures: uint32(9 + i), ConsecutiveFailures: uint32(3 + i), TotalExcludes: 2}, rollingCB.Counts())
 	}
 
 	assert.Equal(t, StateClosed, rollingCB.State())
@@ -364,16 +418,16 @@ func TestRollingWindowCircuitBreaker(t *testing.T) {
 	assert.Nil(t, succeed(rollingCB))
 	assert.Nil(t, succeed(rollingCB))
 	assert.Equal(t, StateHalfOpen, rollingCB.State())
-	assert.Equal(t, Counts{2, 2, 0, 2, 0}, rollingCB.Counts())
+	assert.Equal(t, Counts{Requests: 2, TotalSuccesses: 2, ConsecutiveSuccesses: 2}, rollingCB.Counts())
 
 	// StateHalfOpen to StateClosed
 	ch := succeedLater(rollingCB, time.Duration(100)*time.Millisecond) // 3 consecutive successes
 	time.Sleep(time.Duration(50) * time.Millisecond)
-	assert.Equal(t, Counts{3, 2, 0, 2, 0}, rollingCB.Counts())
+	assert.Equal(t, Counts{Requests: 3, TotalSuccesses: 2, ConsecutiveSuccesses: 2}, rollingCB.Counts())
 	assert.Error(t, succeed(rollingCB)) // over MaxRequests
 	assert.Nil(t, <-ch)
 	assert.Equal(t, StateClosed, rollingCB.State())
-	assert.Equal(t, Counts{0, 0, 0, 0, 0}, rollingCB.Counts())
+	assert.Equal(t, Counts{}, rollingCB.Counts())
 	assert.True(t, rollingCB.expiry.IsZero())
 	assert.Equal(t, StateChange{"rw", StateHalfOpen, StateClosed}, stateChange)
 }
@@ -381,7 +435,7 @@ func TestRollingWindowCircuitBreaker(t *testing.T) {
 func TestPanicInRequest(t *testing.T) {
 	defaultCB := NewCircuitBreaker[bool](Settings{})
 	assert.Panics(t, func() { _ = causePanic(defaultCB) })
-	assert.Equal(t, Counts{1, 0, 1, 0, 1}, defaultCB.Counts())
+	assert.Equal(t, Counts{Requests: 1, TotalFailures: 1, ConsecutiveFailures: 1}, defaultCB.Counts())
 }
 
 func TestGeneration(t *testing.T) {
@@ -390,15 +444,15 @@ func TestGeneration(t *testing.T) {
 	assert.Nil(t, succeed(customCB))
 	ch := succeedLater(customCB, time.Duration(1500)*time.Millisecond)
 	time.Sleep(time.Duration(500) * time.Millisecond)
-	assert.Equal(t, Counts{2, 1, 0, 1, 0}, customCB.Counts())
+	assert.Equal(t, Counts{Requests: 2, TotalSuccesses: 1, ConsecutiveSuccesses: 1}, customCB.Counts())
 
 	time.Sleep(time.Duration(500) * time.Millisecond) // over Interval
 	assert.Equal(t, StateClosed, customCB.State())
-	assert.Equal(t, Counts{0, 0, 0, 0, 0}, customCB.Counts())
+	assert.Equal(t, Counts{}, customCB.Counts())
 
 	// the request from the previous generation has no effect on customCB.windowCounts.Counts
 	assert.Nil(t, <-ch)
-	assert.Equal(t, Counts{0, 0, 0, 0, 0}, customCB.Counts())
+	assert.Equal(t, Counts{}, customCB.Counts())
 }
 
 func TestCustomIsSuccessful(t *testing.T) {
@@ -411,13 +465,14 @@ func TestCustomIsSuccessful(t *testing.T) {
 		assert.Nil(t, fail(cb))
 	}
 	assert.Equal(t, StateClosed, cb.State())
-	assert.Equal(t, Counts{5, 5, 0, 5, 0}, cb.Counts())
+	assert.Equal(t, Counts{Requests: 5, TotalSuccesses: 5, ConsecutiveSuccesses: 5}, cb.Counts())
 
 	cb.counts.clear()
 
-	cb.isSuccessful = func(err error) bool {
-		return err == nil
-	}
+	cb.outcomeEvaluator = outcomeEvaluatorFunc(Settings{
+		IsSuccessful: func(err error) bool { return err == nil },
+	})
+
 	for i := 0; i < 6; i++ {
 		assert.Nil(t, fail(cb))
 	}
@@ -431,10 +486,22 @@ func TestCircuitBreakerInParallel(t *testing.T) {
 	customCB := newCustom(nil)
 	ch := make(chan error)
 
+	var successCount, excludeCount atomic.Uint32
+
 	const numReqs = 10000
 	routine := func() {
 		for i := 0; i < numReqs; i++ {
-			ch <- succeed(customCB)
+			var err error
+			switch i % 2 {
+			case 0:
+				err = succeed(customCB)
+				successCount.Add(1)
+			case 1:
+				err = exclude(customCB)
+				excludeCount.Add(1)
+			}
+
+			ch <- err
 		}
 	}
 
@@ -448,12 +515,42 @@ func TestCircuitBreakerInParallel(t *testing.T) {
 		err := <-ch
 		assert.Nil(t, err)
 	}
-	assert.Equal(t, Counts{total, total, 0, total, 0}, customCB.Counts())
+
+	assert.Equal(t, Counts{Requests: total, TotalSuccesses: successCount.Load(), ConsecutiveSuccesses: successCount.Load(), TotalExcludes: excludeCount.Load()}, customCB.Counts())
+}
+
+func TestExcludeAndIsSuccessfulCombination(t *testing.T) {
+	cb := NewCircuitBreaker[bool](Settings{
+		Exclude: func(err error) bool {
+			return errors.Is(err, errExcluded)
+		},
+		IsSuccessful: func(err error) bool {
+			return err == nil
+		},
+	})
+
+	// Case 1: excluded error -> should be Undetermined (not counted)
+	for i := 0; i < 3; i++ {
+		assert.Nil(t, exclude(cb))
+	}
+	assert.Equal(t, Counts{Requests: 3, TotalExcludes: 3}, cb.Counts(), "excluded errors must not be counted as success or failure")
+
+	// Case 2: nil error -> IsSuccessful says "success"
+	for i := 0; i < 3; i++ {
+		assert.Nil(t, succeed(cb))
+	}
+	assert.Equal(t, Counts{Requests: 6, TotalSuccesses: 3, ConsecutiveSuccesses: 3, TotalExcludes: 3}, cb.Counts(), "nil errors should be counted as success per IsSuccessful")
+
+	// Case 3: not nil error -> IsSuccessful says failure
+	for i := 0; i < 2; i++ {
+		assert.Nil(t, fail(cb))
+	}
+	assert.Equal(t, Counts{Requests: 8, TotalSuccesses: 3, TotalFailures: 2, ConsecutiveFailures: 2, TotalExcludes: 3}, cb.Counts(), "errors should be counted as failures per IsSuccessful")
 }
 
 func TestRollingWindowCircuitBreakerInParallel(t *testing.T) {
 	rollingCB := newRollingWindow(nil)
-	const numGoroutines = 10
+	const numGoroutines = 12
 	const numRequests = 100
 
 	var wg sync.WaitGroup
@@ -463,10 +560,13 @@ func TestRollingWindowCircuitBreakerInParallel(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < numRequests; j++ {
-				if j%2 == 0 {
-					assert.Nil(t, succeed(rollingCB))
-				} else {
-					assert.Nil(t, fail(rollingCB))
+				switch j % 3 {
+				case 0:
+					assert.Nil(t, succeed(rollingCB)) // success
+				case 1:
+					assert.Nil(t, fail(rollingCB)) // failure
+				case 2:
+					assert.Nil(t, exclude(rollingCB)) // exclude
 				}
 			}
 		}()

--- a/v2/twostep_gobreaker.go
+++ b/v2/twostep_gobreaker.go
@@ -32,13 +32,13 @@ func (tscb *TwoStepCircuitBreaker[T]) Counts() Counts {
 // Allow checks if a new request can proceed. It returns a callback that should be used to
 // register the success or failure in a separate step. If the circuit breaker does not allow
 // requests, it returns an error.
-func (tscb *TwoStepCircuitBreaker[T]) Allow() (done func(success bool), err error) {
+func (tscb *TwoStepCircuitBreaker[T]) Allow() (done func(evaluation evaluatedOutcome), err error) {
 	generation, age, err := tscb.cb.beforeRequest()
 	if err != nil {
 		return nil, err
 	}
 
-	return func(success bool) {
-		tscb.cb.afterRequest(generation, age, success)
+	return func(evaluation evaluatedOutcome) {
+		tscb.cb.afterRequest(generation, age, evaluation)
 	}, nil
 }

--- a/v2/twostep_gobreaker_test.go
+++ b/v2/twostep_gobreaker_test.go
@@ -13,7 +13,7 @@ func succeed2Step(cb *TwoStepCircuitBreaker[bool]) error {
 		return err
 	}
 
-	done(true)
+	done(Success)
 	return nil
 }
 
@@ -23,12 +23,36 @@ func fail2Step(cb *TwoStepCircuitBreaker[bool]) error {
 		return err
 	}
 
-	done(false)
+	done(Failure)
+	return nil
+}
+
+func exclude2step(cb *TwoStepCircuitBreaker[bool]) error {
+	done, err := cb.Allow()
+	if err != nil {
+		return err
+	}
+
+	done(Excluded)
+	return nil
+}
+
+func exclude2StepWithDoneDelay(cb *TwoStepCircuitBreaker[bool], delay time.Duration) error {
+	done, err := cb.Allow()
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		time.Sleep(delay)
+		defer done(Excluded)
+	}()
+
 	return nil
 }
 
 func TestTwoStepCircuitBreaker(t *testing.T) {
-	tscb := NewTwoStepCircuitBreaker[bool](Settings{Name: "tscb"})
+	tscb := NewTwoStepCircuitBreaker[bool](Settings{Name: "tscb", MaxRequests: 2})
 	assert.Equal(t, "tscb", tscb.Name())
 
 	for i := 0; i < 5; i++ {
@@ -36,27 +60,28 @@ func TestTwoStepCircuitBreaker(t *testing.T) {
 	}
 
 	assert.Equal(t, StateClosed, tscb.State())
-	assert.Equal(t, Counts{5, 0, 5, 0, 5}, tscb.cb.Counts())
+	assert.Equal(t, Counts{Requests: 5, TotalFailures: 5, ConsecutiveFailures: 5}, tscb.cb.Counts())
 
 	assert.Nil(t, succeed2Step(tscb))
 	assert.Equal(t, StateClosed, tscb.State())
-	assert.Equal(t, Counts{6, 1, 5, 1, 0}, tscb.cb.Counts())
+	assert.Equal(t, Counts{Requests: 6, TotalSuccesses: 1, TotalFailures: 5, ConsecutiveSuccesses: 1}, tscb.cb.Counts())
 
 	assert.Nil(t, fail2Step(tscb))
 	assert.Equal(t, StateClosed, tscb.State())
-	assert.Equal(t, Counts{7, 1, 6, 0, 1}, tscb.cb.Counts())
+	assert.Equal(t, Counts{Requests: 7, TotalSuccesses: 1, TotalFailures: 6, ConsecutiveFailures: 1}, tscb.cb.Counts())
 
 	// StateClosed to StateOpen
 	for i := 0; i < 5; i++ {
 		assert.Nil(t, fail2Step(tscb)) // 6 consecutive failures
 	}
 	assert.Equal(t, StateOpen, tscb.State())
-	assert.Equal(t, Counts{0, 0, 0, 0, 0}, tscb.cb.Counts())
+	assert.Equal(t, Counts{}, tscb.cb.Counts())
 	assert.False(t, tscb.cb.expiry.IsZero())
 
 	assert.Error(t, succeed2Step(tscb))
 	assert.Error(t, fail2Step(tscb))
-	assert.Equal(t, Counts{0, 0, 0, 0, 0}, tscb.cb.Counts())
+	assert.Error(t, exclude2step(tscb))
+	assert.Equal(t, Counts{}, tscb.cb.Counts())
 
 	pseudoSleep(tscb.cb, time.Duration(59)*time.Second)
 	assert.Equal(t, StateOpen, tscb.State())
@@ -66,10 +91,22 @@ func TestTwoStepCircuitBreaker(t *testing.T) {
 	assert.Equal(t, StateHalfOpen, tscb.State())
 	assert.True(t, tscb.cb.expiry.IsZero())
 
+	// In half-open state, when max requests are in progress, others get ErrTooManyRequests
+	// But if in-progress requests complete with Excluded, circuit breaker can accept requests again
+	assert.Nil(t, exclude2StepWithDoneDelay(tscb, 100*time.Millisecond))
+	assert.Nil(t, exclude2StepWithDoneDelay(tscb, 100*time.Millisecond))
+	// Verify new requests are rejected while at capacity
+	assert.Equal(t, ErrTooManyRequests, fail2Step(tscb))
+	assert.Equal(t, ErrTooManyRequests, succeed2Step(tscb))
+	// Wait for excluded requests to complete
+	time.Sleep(110 * time.Millisecond)
+	// Now circuit breaker should accept requests again
+	assert.Nil(t, succeed2Step(tscb))
+
 	// StateHalfOpen to StateOpen
 	assert.Nil(t, fail2Step(tscb))
 	assert.Equal(t, StateOpen, tscb.State())
-	assert.Equal(t, Counts{0, 0, 0, 0, 0}, tscb.cb.Counts())
+	assert.Equal(t, Counts{}, tscb.cb.Counts())
 	assert.False(t, tscb.cb.expiry.IsZero())
 
 	// StateOpen to StateHalfOpen
@@ -79,7 +116,8 @@ func TestTwoStepCircuitBreaker(t *testing.T) {
 
 	// StateHalfOpen to StateClosed
 	assert.Nil(t, succeed2Step(tscb))
+	assert.Nil(t, succeed2Step(tscb))
 	assert.Equal(t, StateClosed, tscb.State())
-	assert.Equal(t, Counts{0, 0, 0, 0, 0}, tscb.cb.Counts())
+	assert.Equal(t, Counts{}, tscb.cb.Counts())
 	assert.True(t, tscb.cb.expiry.IsZero())
 }


### PR DESCRIPTION
- Introduced an EvaluatedOutcome enum (Success, Failure, Excluded) for more accurate request outcome representation.
- Added support for user-defined exclusion logic (e.g., context cancellation).
- Updated the outcome evaluator to handle Excluded results without affecting metrics.
- Extended tests to cover Excluded and undetermined cases.
- Improved documentation for outcome evaluation and exclusion behavior.