### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 on: [push, pull_request]
 name: Test
+permissions:
+  contents: read
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/sony/gobreaker/security/code-scanning/1](https://github.com/sony/gobreaker/security/code-scanning/1)

To fix this, explicitly declare least‑privilege `permissions` for the workflow or for the `test` job. Since this job just checks out code and runs Go tooling and tests, it only needs read access to repository contents; no write or extra scopes are required.

The minimal, non‑functional‑changing fix is to add a `permissions:` block with `contents: read`. You can define it at the root level (applies to all jobs that don’t override it) or within `jobs.test`. Given the small workflow, adding it at the top level is clear and future‑proof.

Concretely, in `.github/workflows/test.yml`, insert:

```yml
permissions:
  contents: read
```

between the existing `name: Test` and `jobs:` lines (i.e., after line 2). No imports or other changes are needed; this is purely a YAML configuration addition and will not change the functional behavior of the workflow aside from constraining the GITHUB_TOKEN.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
